### PR TITLE
Parse https github URL with branch name with slash

### DIFF
--- a/git-host-info.js
+++ b/git-host-info.js
@@ -27,13 +27,22 @@ gitHosts.github = Object.assign({}, defaults, {
   gittemplate: ({ auth, domain, user, project, committish }) => `git://${maybeJoin(auth, '@')}${domain}/${user}/${project}.git${maybeJoin('#', committish)}`,
   tarballtemplate: ({ domain, user, project, committish }) => `https://codeload.${domain}/${user}/${project}/tar.gz/${maybeEncode(committish) || 'master'}`,
   extract: (url) => {
-    let [, user, project, type, committish] = url.pathname.split('/', 5)
-    if (type && type !== 'tree') {
+    let [, user, project, type, ...committish] = url.pathname.split('/')
+
+    if (type && type !== 'tree' && type !== 'pull') {
       return
+    }
+
+    if (type && type === 'pull' && committish.length > 0) {
+      committish = `pull/${committish[0]}/merge`
     }
 
     if (!type) {
       committish = url.hash.slice(1)
+    }
+
+    if (Array.isArray(committish) && type === 'tree') {
+      committish = committish.join('/')
     }
 
     if (project && project.endsWith('.git')) {

--- a/test/github.js
+++ b/test/github.js
@@ -150,6 +150,8 @@ const valid = {
 
   'git+https://github.com/foo/bar.git': { ...defaults, default: 'https' },
   'git+https://github.com/foo/bar.git#branch': { ...defaults, default: 'https', committish: 'branch' },
+  'git+https://github.com/foo/bar/tree/fix/patch': { ...defaults, default: 'https', committish: 'fix/patch' },
+  'git+https://github.com/foo/bar/pull/1': { ...defaults, default: 'https', committish: 'pull/1/merge' },
   'git+https://user@github.com/foo/bar.git': { ...defaults, default: 'https', auth: 'user' },
   'git+https://user@github.com/foo/bar.git#branch': { ...defaults, default: 'https', auth: 'user', committish: 'branch' },
   'git+https://user:password@github.com/foo/bar.git': { ...defaults, default: 'https', auth: 'user:password' },


### PR DESCRIPTION
## Ticket

Refs: https://github.com/pnpm/pnpm/issues/5684

## Details

To support https://github.com/pnpm/pnpm/issues/5684 feature, we should take two actions.

First, we should enable `hosted-git-info`, which pnpm uses to parse https://github.com URL, to parse github URL with branch name with slash and github URL with pull_request.
Second, we should fix pnpm itself not to reckon github URL with branch name or github URL with pull_request as tarball URL. (https://github.com/pnpm/pnpm/blob/main/resolving/tarball-resolver/src/index.ts#L33)

This Pull Request is to take the first action. Of course, we can support https://github.com/pnpm/pnpm/issues/5684 without fixing `hosted-git-info` by arranging github URL before passing github URL into `hosted-git-info` in pnpm itself, but I think we should not do this because it would be more simple and better to consolidate the responsibility into git-hosted-info to parse github URL.